### PR TITLE
Added SwiftDialog support

### DIFF
--- a/patchomator.sh
+++ b/patchomator.sh
@@ -1,4 +1,5 @@
 #!/bin/zsh
+#set -x
 
 # Version: 2023.05.11 - 1.0.3
 # (One Point Oh? Oh!)
@@ -110,7 +111,10 @@ RESET=$(tput sgr0)
 RED=$(tput setaf 1)
 YELLOW=$(tput setaf 3)
 
-# Set SwiftDialog Options:
+# SwiftDialog off by default
+useswiftdialog=false
+
+# Set SwiftDialog Options. Quote your strings. Don't escape line breaks.
 dialogConfigurationOptions=(
 		--title "Patchomator"
 		--message "Updating your apps..."
@@ -632,6 +636,7 @@ queueLabel() {
 zparseopts -D -E -F -K -- \
 -help+=showhelp h+=showhelp \
 -install=installmode I=installmode \
+-swiftdialog=useswiftdialog d=useswiftdialog \
 -quiet=quietmode q=quietmode \
 -yes=noninteractive y=noninteractive \
 -verbose=verbose v=verbose \
@@ -639,7 +644,6 @@ zparseopts -D -E -F -K -- \
 -write=writeconfig w=writeconfig \
 -config:=configfile c:=configfile \
 -pathtoinstallomator:=InstallomatorPATH p:=InstallomatorPATH \
--swiftdialog=useswiftdialog d=useswiftdialog \
 -ignored:=ignoredLabels \
 -required:=requiredLabels
 


### PR DESCRIPTION
- Changed version to 1.0.3
- Added variables to support SwiftDialog (path, command file)
- Added an array to contain all customizable SwiftDialog options. Should make it easy for admins to slot in their own messaging/icons/etc.
- Added new flags `--swiftdialog` or `-d` (I didn't use -s because thats typically used for silent/quiet mode)
- Added new functions:
  - checkSwiftDialog:  If `--swiftdialog` is used, but SwiftDialog is not yet installed, patchomator will use Installomator to install SwiftDialog prior to running other labels
  - swiftDialogCommand: Allows us to send updates to the running dialog window
  - swiftDialogWindow: Builds an array containing the "display name" of each label we're going to process
  - CompleteSwiftDialog: Deletes the tmp command file, and enables the "OK" button so that the dialog can be dismissed.

KNOWN ISSUES:
- Installomator/SwiftDialog integration is not yet perfected, and sometimes the green checkmark won't properly appear in the dialog list. I opted to stick with the built in integration of those two tools, because if it improves in the future then no changes to Patchomator will be needed.
- Patchomator appears to be installing labels listed in "IgnoredLabels". Because those entries in the plist don't have a file path associated with them, it was messing with my changes. I added logic so that any item that doesn't have a file path, also doesn't get listed in the Dialog window. This allowed me to complete the SwiftDialog integration, but it means that Patchomator is installing things that aren't being listed in the Dialog window.