### PR TITLE
Swift dialog supportv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,12 @@ Optional lists of ignored and/or required labels can be added to fine-tune the i
 
 `--pathtoinstallomator "path to Installomator.sh"`	Overrides the default Installomator path for `--install` option.
 
-`-q` | `--quiet`	 *Quiet mode*. Minimal output.
+`-q` | `--quiet`	    *Quiet mode*. Minimal output.
 
-`-v` | `--verbose`	 *Verbose mode*. Logs more information to stdout. Overrides -q
+`-v` | `--verbose`	    *Verbose mode*. Logs more information to stdout. Overrides -q
+`-d` | `--swiftdialog`  Use SwiftDialog to provide end users with feedback about what's happening
 
-`-h` | `--help` 	 Show usage message and exits.
+`-h` | `--help` 	    Show usage message and exits.
 
 
 When run, Patchomator will prompt you to install Installomator, if it doesn't already exist at the default path or the one specified with `-p [InstallomatorPATH]`. Patchomator will happily run without Installomator, but won't actually install any updates by itself.
@@ -132,6 +133,8 @@ and as a one-time switch on the command line with `--required`
 
 ```patchomator.sh --required "googlechromepkg zoom"```
 
+## SwiftDialog Integration
+Use `--swiftdialog` or `-d` to get a SwiftDialog list view of each item thats being processed. Updates are sent to the dialog via native Installomator/SwiftDialog integration.
 
 ## Patching with Patchomator
 

--- a/patchomator.sh
+++ b/patchomator.sh
@@ -1,6 +1,7 @@
 #!/bin/zsh
+set -x
 
-# Version: 2023.05.12 - 1.0.3
+# Version: 2023.05.12 - 1.0.4
 # ("Hey... I think it is actually running now")
 
 #  Big Thanks to:
@@ -27,6 +28,7 @@
 # git and Xcode tools are optional now. Did you know GitHub has a pretty decent API?
 # No longer requires root for normal operation. (thanks, @tlark)
 # Downloads XCode Command Line Tools to provide git (Thanks Adam Codega)
+# Added SwiftDialog support with --swiftdialog or -d options (Thanks Trevor Sysock @BigMacAdmin)
 
 # Done:
 # Install package/github release
@@ -97,6 +99,8 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
 InstallomatorPATH=("/usr/local/Installomator/Installomator.sh")
 configfile=("/Library/Application Support/Patchomator/patchomator.plist")
+dialogPATH="/usr/local/bin/dialog"
+dialogCommandFile=$(mktemp /var/tmp/dialog.patchomator.XXXXX)
 #patchomatorPath=$(dirname $(realpath $0)) # default install at /usr/local/Installomator/
 
 # "realpath" doesn't exist on Monterey. 
@@ -110,7 +114,21 @@ RESET=$(tput sgr0 2>/dev/null)
 RED=$(tput setaf 1 2>/dev/null)
 YELLOW=$(tput setaf 3 2>/dev/null)
 
+# SwiftDialog off by default
+useswiftdialog=false
 
+# Set SwiftDialog Options. Quote your strings. Don't escape line breaks.
+dialogConfigurationOptions=(
+		--title "Patchomator"
+		--message "Updating your apps..."
+		--commandfile "$dialogCommandFile"
+		--ontop
+		--moveable
+		--button1disabled
+		--height 550
+		--width 1000
+		--icon "SF=bolt.circle color1=pink color2=blue"
+)
 
 #######################################
 # Functions
@@ -127,6 +145,7 @@ usage() {
 	echo "\t${BOLD}-q | --quiet \t${RESET} Quiet mode. Minimal output."
 	echo "\t${BOLD}-v | --verbose \t${RESET} Verbose mode. Logs more information to stdout. Overrides ${BOLD}--quiet${RESET}"
 	echo "\t${BOLD}-I | --install \t${RESET} Install mode. This parses an existing configuration and sends the commands to Installomator to update. ${BOLD}Requires sudo${RESET}"
+	echo "\t${BOLD}-I | --swiftdialog \t${RESET} Create a SwiftDialog list to show progress to end user.${BOLD}Cannot be used at the login window, requires an active user.${RESET}"
 	echo "\t${BOLD}-p | --pathtoinstallomator \"path to Installomator.sh\"${RESET}\n\tDefault Installomator Path ${YELLOW}/usr/local/Installomator/Installomator.sh${RESET}"
 	echo "\t${BOLD}-h | --help \t${RESET} Show this text and exit.\n"
 	echo "${YELLOW}See readme for more options and examples: ${BOLD}https://github.com/mac-nerd/Patchomator{RESET}"
@@ -346,10 +365,28 @@ doInstallations() {
 	# Count errors
 	errorCount=0
 
+	# Create our swiftDialog Window
+	swiftDialogWindow
+
 	for label in $queuedLabelsArray
 	do
 		echo "Installing ${label}..."
-		${InstallomatorPATH} ${label} ${InstallomatorOptions}
+
+		# Use built in SwiftDialog Installomator integration options (if swift dialog is being used)
+		swiftDialogOptions=()
+		if $useswiftdialog
+		then
+			swiftDialogOptions+=(DIALOG_CMD_FILE="\"${dialogCommandFile}\"")
+
+			# Get the "name=" value from the current label and use it in our SwiftDialog list
+			currentDisplayName=$(sed -n '/# label descriptions/,$p' ${InstallomatorPATH} | grep -i -A 50 "${label})" | grep -m 1 "name=" | sed 's/.*=//' | sed 's/"//g')
+			# There are some weird \' shenanigans here because Installomator passes this through eval
+			swiftDialogOptions+=(DIALOG_LIST_ITEM_NAME=\'"${currentDisplayName}"\')
+			sleep .5
+		fi
+
+		# Run Installomator
+		${InstallomatorPATH} ${label} ${InstallomatorOptions} ${swiftDialogOptions[@]}
 		if [ $? != 0 ]; then
 			error "Error installing ${label}. Exit code $?"
 			let errorCount++
@@ -358,10 +395,76 @@ doInstallations() {
 
 	echo "Errors: $errorCount"
 
+	# Close swiftdialog and delete tmp file
+	CompleteSwiftDialog
+
 	caffexit $errorCount
 
 }
- 
+
+checkSwiftDialog(){
+	if [ ! -e "/usr/local/bin/dialog" ] || [ ! -e "/Library/Application Support/Dialog/Dialog.app" ]
+	then
+		echo "SwiftDialog is not installed. Using Installomator to install it now."
+		${InstallomatorPATH} swiftdialog NOTIFY=success
+	fi
+}
+
+swiftDialogCommand(){
+	if $useswiftdialog
+	then	
+		echo "$@" > "$dialogCommandFile"
+		#sleep 1
+	fi
+}
+
+swiftDialogWindow(){
+# If we are using SwiftDialog
+	if $useswiftdialog
+	then
+		# Check if there's a valid logged in user:
+		currentUser=$(scutil <<< "show State:/Users/ConsoleUser" | awk '/Name :/ { print $3 }')
+		if [ "$currentUser" = "root" ] \
+			|| [ "$currentUser" = "loginwindow" ] \
+			|| [ "$currentUser" = "_mbsetupuser" ] \
+			|| [ -z "$currentUser" ] 
+		then
+			return 0
+		fi
+		# Install SwiftDialog if its not already there
+		checkSwiftDialog
+
+		# Build our list of Display Names for SwiftDialog list
+		for label in $queuedLabelsArray
+		do
+			# Get the "name=" value from the current label and use it in our SwiftDialog list
+			currentDisplayName=$(sed -n '/# label descriptions/,$p' ${InstallomatorPATH} | grep -i -A 50 "${label})" | grep -m 1 "name=" | sed 's/.*=//' | sed 's/"//g')
+			if [ -n "$currentDisplayName" ]
+			then
+				displayNames+=("--listitem")
+				displayNames+=(${currentDisplayName})
+			fi
+		done
+		# Create our running swiftDialog window
+		$dialogPATH \
+		${dialogConfigurationOptions[@]} \
+		${displayNames[@]} \
+		&
+	fi
+}
+
+CompleteSwiftDialog(){
+	if $swiftDialog
+	then
+		swiftDialogCommand "listitem: add, title: Updates Complete!,status: success"
+		sleep 1
+		# Activate button 1
+		swiftDialogCommand "button1: enabled"
+	fi
+	# Delete the tmp command file
+	rm "$dialogCommandFile"
+}
+
  
 PgetAppVersion() {
 	# renamed to avoid conflicts with Installomator version of the same function name.
@@ -541,6 +644,7 @@ queueLabel() {
 zparseopts -D -E -F -K -- \
 -help+=showhelp h+=showhelp \
 -install=installmode I=installmode \
+-swiftdialog=useswiftdialog d=useswiftdialog \
 -quiet=quietmode q=quietmode \
 -yes=noninteractive y=noninteractive \
 -verbose=verbose v=verbose \
@@ -655,6 +759,13 @@ then
 		fatal "Install mode must be run with root/sudo privileges. Re-run Patchomator with\n\t ${YELLOW}sudo zsh patchomator.sh --install${RESET}"
 	fi
 	
+fi
+
+# --swiftdialog
+# if --swiftdialog argument is passed, then swiftdialog will be used
+if [[ ${#useswiftdialog} -eq 1 ]]
+then
+	useswiftdialog=true
 fi
 
 # discovery mode


### PR DESCRIPTION
-   Changed version to 1.0.4
-   Added variables to support SwiftDialog (path, command file)
-   Added an array to contain all customizable SwiftDialog options. Should make it easy for admins to slot in their own messaging/icons/etc.
-   Added new flags `--swiftdialog` or `-d` (I didn't use -s because thats typically used for silent/quiet mode)
-   Added new functions:
    -   checkSwiftDialog: If `--swiftdialog` is used, but SwiftDialog is not yet installed, patchomator will use Installomator to install SwiftDialog prior to running other labels
    -   swiftDialogCommand: Allows us to send updates to the running dialog window
    -   swiftDialogWindow: Builds an array containing the "display name" of each label we're going to process
    -   CompleteSwiftDialog: Deletes the tmp command file, and enables the "OK" button so that the dialog can be dismissed.