### PR TITLE
Adding initial managed config file support

### DIFF
--- a/patchomator.sh
+++ b/patchomator.sh
@@ -130,6 +130,7 @@ export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
 InstallomatorPATH=("/usr/local/Installomator/Installomator.sh")
 configfile=("/Library/Application Support/Patchomator/patchomator.plist")
+managedConfigfile=("/Library/Managed Preferences/com.mac-nerd.patchomator.plist")
 #patchomatorPath=$(dirname $(realpath $0)) # default install at /usr/local/Installomator/
 
 # "realpath" doesn't exist on Monterey. 
@@ -745,7 +746,19 @@ fi
 
 notice "Verbose Mode enabled." # and if it's not? This won't echo.
 
-configfile=$configfile[-1] # either provided on the command line, or default path
+if ! [[ -f $configfile[-1] ]] && [[ -f $managedConfigfile ]]
+then
+	configfile=$managedConfigfile
+else
+	configfile=$configfile[-1] # either provided on the command line, or default path
+fi
+
+# prevent patchomator modify the content of the managed config
+if [[ $configfile == $managedConfigfile ]] && [[ ${#writeconfig} -eq 1 ]]
+then
+	fatal "You should not manualy overwrite ${YELLOW}$managedConfigfile${RESET}"
+fi
+
 InstallomatorPATH=$InstallomatorPATH[-1] # either provided on the command line, or default /usr/local/Installomator
 
 MDMName=$MDMName[-1] #[one of jamf, mosyleb, mosylem, addigy, microsoft, ws1, other ]


### PR DESCRIPTION
As discussed here : https://macadmins.slack.com/archives/C04V0BC98PQ/p1712157866087659
I added initial support for managed config files to my fork of Patchomator. The parameter that can be managed are "IgnoredLabels" and "RequiredLabels".

1. For now, the easiest way to create a config profile is by using the command :
```defaults write /path/to/patchomator.plist IgnoredLabels/RequiredLabels -array label1 label2 label3```
2. And convert this plist file to a profile with https://github.com/scriptingosx/swift-prefs/. 
3. It can then be deployed by any MDM that support custom profiles.

I also wrote a Profile manifest for ProfileCreator and iMazing Profile Editor to create this config profile. I'll create a pull request for it if you want to merge this pull request.

If a configfile already exists, nothing will change, it will always be loaded first. I also added a way to prevent the managedConfigfile to be overwritten, as this is not desired with a profile.