### PR TITLE
Remove Extra Spaces

### DIFF
--- a/patchomator.sh
+++ b/patchomator.sh
@@ -1188,23 +1188,32 @@ else
 	ignoredLabelsList+=($ignoredLabelsFromConfig)
 	requiredLabelsList+=($requiredLabelsFromConfig)
 
-	labelsList+=($labelsFromConfig $requiredLabels $requiredLabelsFromConfig)
+	labelsList+=($labelsFromConfig $requiredLabelsList)
 	
-# 	# deduplicate ignored labels
+# 	# deduplicate ignored labels and remove extra spacing
 	ignoredLabelsList=($(tr ' ' '\n' <<< "${ignoredLabelsList[@]}" | sort -u | tr '\n' ' '))
+  	ignoredLabelsList="${ignoredLabelsList## }"
+	ignoredLabelsList="${ignoredLabelsList%% }"
+ 	ignoredLabelsList="${ignoredLabelsList//[[:space:]]+/  }"
 
-# 	# deduplicate required labels
+# 	# deduplicate required labels and remove extra spacing
 	requiredLabelsList=($(tr ' ' '\n' <<< "${requiredLabelsList[@]}" | sort -u | tr '\n' ' '))
+  	requiredLabelsList="${requiredLabelsList## }"
+	requiredLabelsList="${requiredLabelsList%% }"
+ 	requiredLabelsList="${requiredLabelsList//[[:space:]]+/  }"
 
-# 	# deduplicate labels list
+# 	# deduplicate labels list and remove extra spacing
 	labelsList=($(tr ' ' '\n' <<< "${labelsList[@]}" | sort -u | tr '\n' ' '))
+ 	labelsList="${labelsList## }"
+	labelsList="${labelsList%% }"
+ 	labelsList="${labelsList//[[:space:]]+/  }"
 
+#	# remove ignored labels
 	labelsList=${labelsList:|ignoredLabelsList}
 
 	notice "Labels to install: $labelsList"
 	notice "Ignoring labels: $ignoredLabelsList"
-	notice "Required labels: $requiredLabelsList"
-	
+	notice "Required labels: $requiredLabelsList"	
 	
 fi	
 # end discovery	
@@ -1288,7 +1297,7 @@ then
 	IFS=' '
 
 	queuedLabelsArray=("${(@s/ /)labelsList}")	
-	numLabels=$((${#queuedLabelsArray[@]} - 1))
+	numLabels=${#queuedLabelsArray[@]}
 
 	if [[ $numLabels > 0 ]]
 	then

--- a/patchomator.sh
+++ b/patchomator.sh
@@ -759,10 +759,11 @@ fi
 
 notice "Verbose Mode enabled." # and if it's not? This won't echo.
 
-if [[ ${#configfile} -lt 1 ]] && [[ -f $managedConfigfile ]]
+if [[ ${#configfile} -eq 0 ]] && [[ -f $managedConfigfile ]]
 then
 	defaultConfigfile=$managedConfigfile
-else
+elif [[ ${#configfile} -gt 0 ]]
+then
 	defaultConfigfile=$configfile[-1] # either provided on the command line, or default path	
 fi
 


### PR DESCRIPTION
Updated the script to remove extra spaces, and use the requiredLabelsList variable instead of requiredLabels variable which includes the --required string. Also removed the subtract 1 from the number of labels caused by the extra spaces, and fixed the config file to work if not using managed config files or a command line argument.