### PR TITLE
feat: add meeting detection to defer installs during calls

### DIFF
--- a/patchomator.sh
+++ b/patchomator.sh
@@ -181,6 +181,9 @@ fi
 # If you find this helpful, and want to add other labels to the distributed script, open a PR at https://github.com/Mac-Nerd/patchomator/
 recommendedIgnores=("bbedit" "firefox" "firefox_da" "firefox_intl" "firefoxesr" "firefoxesr_intl" "firefoxpkg_intl" "googlechrome" "googlechromeenterprise" "microsoftofficebusinesspro" "microsoftonedrive-deferred" "microsoftonedrive-rollingout" "microsoftonedrive-rollingoutdeferred" "microsoftonedrivesuinsiders" "microsoftonedrivesuprod" "microsoftoutlook-monthly" "zoomgov" "zoomclient" "virtualboxbeta" "virtualboxlatest" "virtualboxstable") 
 
+### Meeting Detection default (empty = disabled, "true" = enabled)
+defaultCheckMeetingStatus=""
+
 ### Default Installomator Options:
 InstallomatorOptions=(\
 [NOTIFY]=success \
@@ -228,6 +231,7 @@ usage() {
 	echo "\t${BOLD}-o | --options \"option1=value option2=value ...\"${RESET}\tCommand line options passed through to Installomator.${RESET}"
 	echo "\t${BOLD}-m | --mdm \"name\"${RESET}\tOne of jamf, mosyleb, mosylem, addigy, microsoft, ws1, kandji, filewave. Changes the Swift Dialog icon to the respective MDM icon.${RESET}"
 	echo "\t${BOLD}-t | --timeout integer${RESET}\tSets the replace label timeout to specified integer. Cannot be less than 10 or over 9000 or it will default to $defaultPromptTimeoutMax seconds.${RESET}"
+	echo "\t${BOLD}--check-meetings${RESET}\tCheck for active video calls (Zoom, Meet, Teams, FaceTime), screen sharing, Focus/DND, and presentations. Defers installations if detected.${RESET}"
 	echo "${YELLOW}See readme for more options and examples: ${BOLD}https://github.com/mac-nerd/Patchomator${RESET}"
 	exit 0
 }
@@ -558,6 +562,96 @@ downloadLatestLabels() {
 	# Remove the temporary working directory when done
 	notice "Deleting working directory '$temptarDirectory' and its contents"
 	rm -Rf "$temptarDirectory" 2>/dev/null
+}
+
+#######################################
+# Meeting Detection
+# Checks for active video calls, screen sharing, Focus/DND, or presentations.
+# Returns 0 if no meeting detected (OK to update), 1 if meeting active (defer).
+# Complements Installomator's INTERRUPT_DND by checking app-level signals
+# (active call processes, camera/audio usage, browser tabs) that DND alone
+# does not cover — a user can be in a Zoom call without Focus mode enabled.
+checkMeetingStatus() {
+	local currentUser
+	currentUser=$(stat -f%Su /dev/console)
+
+	if [[ -z "$currentUser" ]] || [[ "$currentUser" == "root" ]] || [[ "$currentUser" == "loginwindow" ]]; then
+		notice "No user logged in, OK to update."
+		return 0
+	fi
+
+	# Check for Focus/Do Not Disturb (macOS 12+)
+	local focusState=0
+	focusState=$(plutil -extract data.0.storeAssertionRecords json -o - \
+		"/Users/$currentUser/Library/DoNotDisturb/DB/Assertions.json" 2>/dev/null | \
+		grep -c "assertionIdentifier" 2>/dev/null) || focusState=0
+	[[ ! "$focusState" =~ ^[0-9]+$ ]] && focusState=0
+	if [[ "$focusState" -gt 0 ]]; then
+		infoOut "Focus/DND mode active. Deferring updates."
+		return 1
+	fi
+
+	# Check for active Zoom meeting (CptHost = in-call)
+	if pgrep -x "zoom.us" > /dev/null 2>&1; then
+		if pgrep -x "CptHost" > /dev/null 2>&1; then
+			infoOut "Active Zoom meeting detected. Deferring updates."
+			return 1
+		fi
+	fi
+
+	# Check for active Google Meet (Chrome tab with meet.google.com)
+	if pgrep -x "Google Chrome" > /dev/null 2>&1; then
+		local meetTab
+		meetTab=$(osascript -e '
+			tell application "Google Chrome"
+				repeat with w in windows
+					repeat with t in tabs of w
+						if URL of t contains "meet.google.com" then
+							return "active"
+						end if
+					end repeat
+				end repeat
+			end tell
+			return "none"
+		' 2>/dev/null)
+		if [[ "$meetTab" == "active" ]]; then
+			infoOut "Active Google Meet detected. Deferring updates."
+			return 1
+		fi
+	fi
+
+	# Check for active Microsoft Teams call (audio/camera usage)
+	if pgrep -x "Microsoft Teams" > /dev/null 2>&1; then
+		if lsof 2>/dev/null | grep -qi "teams.*coreaudio\|teams.*applecamera"; then
+			infoOut "Active Microsoft Teams call detected. Deferring updates."
+			return 1
+		fi
+	fi
+
+	# Check for active FaceTime call
+	if pgrep -x "FaceTime" > /dev/null 2>&1; then
+		if pgrep -x "avconferenced" > /dev/null 2>&1; then
+			infoOut "Active FaceTime call detected. Deferring updates."
+			return 1
+		fi
+	fi
+
+	# Check for active screen sharing/recording
+	if pgrep -x "screencaptureui" > /dev/null 2>&1; then
+		infoOut "Screen sharing/recording active. Deferring updates."
+		return 1
+	fi
+
+	# Check for Keynote slideshow in progress
+	if pgrep -x "Keynote" > /dev/null 2>&1; then
+		if osascript -e 'tell application "Keynote" to return playing' 2>/dev/null | grep -q "true"; then
+			infoOut "Keynote presentation in progress. Deferring updates."
+			return 1
+		fi
+	fi
+
+	notice "No active meetings detected."
+	return 0
 }
 
 # --install
@@ -1073,6 +1167,7 @@ zparseopts -D -E -F -K -- \
 -everywhere=everywhere e=everywhere \
 -options:=cliOptions o:=cliOptions \
 -proxy:=cliPROXY \
+-check-meetings=checkMeetings \
 || fatal "Bad command line option. See patchomator.sh --help"
 
 # -h --help
@@ -1302,6 +1397,30 @@ elif [[ ! -f "$logPATH" ]] then
 fi
 
 echo "Patchomator starting: $(date '+%F %H:%M:%S')" | tee -a "$logPATH"
+
+# -------------------------------------------------------------------------
+# Meeting Detection (checked before any installations)
+# -------------------------------------------------------------------------
+meetingDetection="$defaultCheckMeetingStatus"
+
+# Read from managed plist if present
+if [[ -f "$managedConfigFile" ]]; then
+	plistCheckMeetings=$(/usr/libexec/PlistBuddy -c "Print :CheckMeetingStatus" "$managedConfigFile" 2>/dev/null)
+	[[ -n "$plistCheckMeetings" ]] && meetingDetection="$plistCheckMeetings"
+fi
+
+# CLI flag overrides everything
+if (( ${#checkMeetings} )); then
+	meetingDetection="true"
+fi
+
+# Run meeting check (only in install mode — discovery can run anytime)
+if (( ${#installmode} )) && [[ "$meetingDetection" == "true" ]]; then
+	if ! checkMeetingStatus; then
+		echo "Active meeting detected. Deferring updates." | tee -a "$logPATH"
+		finishAndExit 0
+	fi
+fi
 
 notice "Option Count ${#InstallomatorOptions[@]}"
 notice "Installomator Options:"


### PR DESCRIPTION
## Summary

Adds an opt-in `--check-meetings` flag that checks for active video calls, screen sharing, Focus/DND mode, and presentations before running installations. If any are detected, Patchomator logs the reason and exits cleanly.

*Split from #37 per your feedback — update window removed (agreed that the MDM should handle scheduling).*

### What it detects

| Signal | Detection Method |
|--------|-----------------|
| **Zoom** | `CptHost` process (active call indicator) |
| **Google Meet** | Chrome tab URL contains `meet.google.com` |
| **Microsoft Teams** | `lsof` check for CoreAudio/AppleCamera usage |
| **FaceTime** | `avconferenced` process |
| **Screen sharing** | `screencaptureui` process |
| **Focus/DND** | macOS 12+ Assertions.json |
| **Keynote** | AppleScript `playing` property |

### How it complements Installomator's INTERRUPT_DND

Installomator's `INTERRUPT_DND` setting controls whether *notifications* are suppressed during Do Not Disturb. It doesn't check whether the user is actually in a call — a user can be on a Zoom call without Focus mode enabled. This feature checks app-level signals (active call processes, camera/audio usage, browser tabs) that DND alone does not cover.

The two features are complementary:
- **INTERRUPT_DND** → "Should I show a notification?"
- **--check-meetings** → "Should I run at all?"

### Configuration

Three methods, in priority order: CLI > managed plist > script default.

**CLI:**
```bash
sudo patchomator.sh --install --yes --check-meetings
```

**Managed preferences** (`com.mac-nerd.patchomator.plist`):
```xml
<key>CheckMeetingStatus</key>
<string>true</string>
```

**Script default:**
```bash
defaultCheckMeetingStatus="true"
```

### Design decisions

- **Opt-in only** — disabled by default, zero behavior change for existing users
- **Install mode only** — discovery and config writes are unaffected
- **Clean exit (0)** — MDM policies don't report failures when deferred
- **Lightweight checks** — process checks (`pgrep`) are fast; `osascript` and `lsof` only run when the relevant app is already detected as running
- **No new dependencies** — uses only built-in macOS tools

## Test Plan

- [ ] `--check-meetings` defers when Zoom CptHost is running
- [ ] `--check-meetings` defers when Google Meet tab is open in Chrome
- [ ] `--check-meetings` defers when Focus mode is active
- [ ] `--check-meetings` proceeds when no meeting apps are active
- [ ] `--check-meetings` proceeds when no user is logged in
- [ ] Managed plist `CheckMeetingStatus=true` enables detection without CLI flag
- [ ] Discovery mode (`--write`) ignores meeting check
- [ ] No flag = existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)