### PR TITLE
Add minimize button to progress/prompt dialog windows

### DIFF
--- a/patchomator.sh
+++ b/patchomator.sh
@@ -1,6 +1,6 @@
 #!/bin/zsh
 
-VERSION="1.2"
+VERSION="1.2-om1"
 VERSIONDATE="2025-10-27"
 VERSIONNAME="One Point Spooky"
 
@@ -729,6 +729,7 @@ dialogTimeoutPrompt() {
 		--button2text "$button2" \
 		--ontop \
 		--moveable \
+		--windowbuttons min \
 		--position "center" \
 		--commandfile "$commandFile" > /dev/null 2>&1
 	dialogTimeoutRet=$(echo $?)
@@ -1345,6 +1346,7 @@ if (( ! ${#quietmode} )) && [[ -f /usr/local/bin/dialog ]] && [[ "$DialogPATH" !
 		--button1text "..." \
 		--ontop \
 		--moveable \
+		--windowbuttons min \
 		--position "center" \
 		--commandfile "$DialogPATH" > /dev/null 2>&1 &
 	sleep 0.1


### PR DESCRIPTION
## What

Adds swiftDialog's `--windowbuttons min` flag to Patchomator's two swiftDialog invocations:

- The main "Patchomator Progress" dialog (the mini progress window shown during discovery/verification/install)
- `dialogTimeoutPrompt()` (used for the "Replace label...?" and "Install Installomator?" prompts)

Also bumps `VERSION` from `1.2` to `1.2-om1` to distinguish this build.

## Why

swiftDialog's `--windowbuttons` option controls which of the standard macOS title-bar window controls (close/minimize/zoom) are drawn on the dialog. Passing `min` adds just the yellow minimize button.

Today both dialogs are shown with `--ontop` and `--moveable` but no window controls at all, so there is no way for a user (or admin watching over someone's shoulder) to get the dialog out of the way during a run — it can be dragged around, but not minimized or hidden, and it will stay on top of everything else on screen for the whole run. For --install runs in particular, this can be a long-running, unattended-feeling window with no way to tuck it out of sight. Adding the minimize button gives users an unobtrusive way to temporarily dismiss the window without closing/canceling the underlying process.

## What's intentionally unchanged

`--ontop` and `--moveable` are left exactly as they were on both invocations. This change only adds the ability to minimize; it does not change stacking behavior or make the dialogs any less "always on top" than before, and it does not add a close button.

## Testing

Patched and rebuilt locally; the two `--windowbuttons min` additions and the version bump have been verified byte-for-byte against the pushed branch content.